### PR TITLE
fix: inject app version into Docker builds via ldflags

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -51,6 +51,11 @@ jobs:
             type=semver,pattern={{major}}
             type=raw,value=latest,enable={{is_default_branch}}
 
+      # Extract version from tag
+      - name: Get version
+        id: get_version
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
       # Build and push Docker image
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
@@ -60,5 +65,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: VERSION=${{ steps.get_version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM golang:1.26-alpine AS builder
 
 WORKDIR /app
 
+ARG VERSION=dev
+
 # Copy go.mod and go.sum files and download dependencies
 COPY go.mod go.sum* ./
 RUN go mod download
@@ -10,7 +12,7 @@ RUN go mod download
 COPY . .
 
 # Build the application
-RUN CGO_ENABLED=0 GOOS=linux go build -o dashboard-exporter .
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-X 'main.Version=${VERSION}'" -o dashboard-exporter .
 
 # Use a smaller image for the final container
 FROM alpine:3.19


### PR DESCRIPTION
Add VERSION build arg to Dockerfile and pass it from the tag in docker-publish.yml so the footer shows the actual release version instead of "dev".